### PR TITLE
NP-0000 fix: remove deprecated homebrew-cask-versions

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -8,8 +8,7 @@
   - name: Add custom homebrew repos
     community.general.homebrew_tap:
       name: [
-        heroku/brew,
-        homebrew/cask-versions
+        heroku/brew
       ]
 
   - name: Install core packages via brew casks


### PR DESCRIPTION
# Removes deprecated `homebrew-cask-versions`

Apparently it's deprecated and it's part of brew normally anyway.