### PR TITLE
fix: fix install brew and bump timeout

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ function install_brew() {
 
 echo "3) Installing home brew";
 
-install_brew();
+install_brew
 
 echo "4) Generating ssh key";
 

--- a/main.yml
+++ b/main.yml
@@ -33,7 +33,7 @@
 
   - name: gh_login
     shell: gh auth status || yes | ((gh auth login -h github.com -s  admin:public_key -w -p ssh) 2> /tmp/out)
-    async: 100
+    async: 300
     poll: 0
     register: gh_login
     when: gh_status is failed


### PR DESCRIPTION
Install brew wasn't being called correctly so it would error out by the the time it got the to ansible script.

Also, 100 seconds wasn't enough time for me to find and type my 30 character gh password so just a quality of life change there.

Otherwise I think this part would have run unattended.